### PR TITLE
Add ASCII xor/nor/nand operators

### DIFF
--- a/src/WeberLogic.js
+++ b/src/WeberLogic.js
@@ -121,6 +121,9 @@
         not: function(value) { return !value; },
         and: function(lhs, rhs) { return lhs && rhs; },
         or: function(lhs, rhs) { return lhs || rhs;  },
+        xor: function(lhs, rhs) { return lhs ? !rhs : rhs; },
+        nand: function(lhs, rhs) { return !(lhs && rhs); },
+        nor: function(lhs, rhs) { return !(lhs || rhs);  },
         implies: function(lhs, rhs) { return this.or(this.not(lhs), rhs); },
         iff: function(lhs, rhs) { return this.and(this.implies(lhs,rhs), this.implies(rhs,lhs)); } 
     };

--- a/src/WeberLogic.js
+++ b/src/WeberLogic.js
@@ -176,13 +176,15 @@
 expression = _ expression:level_1 _ { return new Expression(expression); }
  
 level_1
-      = _ left:level_2 _ right:_level_1_ _ { return right(left); }
-      / _ x:level_2 _ { return x; }
+    = _ left:level_2 _ right:_level_1_ _ { return right(left); }
+    / _ x:level_2 _ { return x; }
 _level_1_
-      = _ "<->" _ right:level_1 _ { return function(left) { return new Iff(left, right) }};
+    = _ "<->" _ right:level_1 _ { return function(left) { return new Iff(left, right) }}
+    / _ "⇔" _ right:level_1 _ { return function(left) { return new Iff(left, right) }}
  
 level_2
     = _ left:level_3 _ "->" _ right:level_2 _ { return new Implies(left,right); }
+    / _ left:level_3 _ "⇒" _ right:level_2 _ { return new Implies(left,right); }
     / _ x:level_3 _ { return x; }
  
 level_3 
@@ -190,18 +192,25 @@ level_3
     / _ x:level_4 _ { return x; } 
 _level_3_ 
     = _ "|" _ right:level_3 _ { return function(left) { return new Or(left, right); } }
+    / _ "∨" _ right:level_3 _ { return function(left) { return new Or(left, right); } }
     / _ "^" _ right:level_3 _ { return function(left) { return new Xor(left, right); } }
+    / _ "⊕" _ right:level_3 _ { return function(left) { return new Xor(left, right); } }
+    / _ "⊻" _ right:level_3 _ { return function(left) { return new Xor(left, right); } }
     / _ "~|" _ right:level_3 _ { return function(left) { return new Nor(left, right); } }
+    / _ "⊽" _ right:level_3 _ { return function(left) { return new Nor(left, right); } }
     
 level_4 
     = _ left:level_5 _ right:_level_4_ _ { return right(left); }
     / _ x:level_5 _ { return x; } 
 _level_4_ 
     = _ "&" _ right:level_4 _ { return function(left) { return new And(left, right); } }
+    / _ "∧" _ right:level_4 _ { return function(left) { return new And(left, right); } }
     / _ "~&" _ right:level_4 _ { return function(left) { return new Nand(left, right); } }
+    / _ "⊼" _ right:level_4 _ { return function(left) { return new Nand(left, right); } }
   
 level_5 
     = _ "~" _ right:level_5 _ { return new Not(right); }
+    / _ "¬" _ right:level_5 _ { return new Not(right); }
     / _ "(" _ x:level_1 _ ")" _ { return x; }
     / _ x:predicate _ { return x; }
  

--- a/src/WeberLogic.js
+++ b/src/WeberLogic.js
@@ -189,8 +189,11 @@ level_3
     = _ left:level_4 _ right:_level_3_ _ { return right(left); }
     / _ x:level_4 _ { return x; } 
 _level_3_ 
-    = _ "&" _ right:level_3 _ { return function(left) { return new And(left, right); } }
-    / _ "|" _ right:level_3 _ { return function(left) { return new Or(left, right); } }
+    = _ "|" _ right:level_3 _ { return function(left) { return new Or(left, right); } }
+    / _ "^" _ right:level_3 _ { return function(left) { return new Xor(left, right); } }
+    / _ "~|" _ right:level_3 _ { return function(left) { return new Nor(left, right); } }
+    / _ "&" _ right:level_3 _ { return function(left) { return new And(left, right); } }
+    / _ "~&" _ right:level_3 _ { return function(left) { return new Nand(left, right); } }
   
 level_4 
     = _ "~" _ right:level_4 _ { return new Not(right); }

--- a/src/WeberLogic.js
+++ b/src/WeberLogic.js
@@ -192,11 +192,16 @@ _level_3_
     = _ "|" _ right:level_3 _ { return function(left) { return new Or(left, right); } }
     / _ "^" _ right:level_3 _ { return function(left) { return new Xor(left, right); } }
     / _ "~|" _ right:level_3 _ { return function(left) { return new Nor(left, right); } }
-    / _ "&" _ right:level_3 _ { return function(left) { return new And(left, right); } }
-    / _ "~&" _ right:level_3 _ { return function(left) { return new Nand(left, right); } }
-  
+    
 level_4 
-    = _ "~" _ right:level_4 _ { return new Not(right); }
+    = _ left:level_5 _ right:_level_4_ _ { return right(left); }
+    / _ x:level_5 _ { return x; } 
+_level_4_ 
+    = _ "&" _ right:level_4 _ { return function(left) { return new And(left, right); } }
+    / _ "~&" _ right:level_4 _ { return function(left) { return new Nand(left, right); } }
+  
+level_5 
+    = _ "~" _ right:level_5 _ { return new Not(right); }
     / _ "(" _ x:level_1 _ ")" _ { return x; }
     / _ x:predicate _ { return x; }
  

--- a/src/WeberLogic.js
+++ b/src/WeberLogic.js
@@ -147,12 +147,12 @@
     truthTable = {
         not: function(value) { return !value; },
         and: function(lhs, rhs) { return lhs && rhs; },
-        or: function(lhs, rhs) { return lhs || rhs;  },
-        xor: function(lhs, rhs) { return lhs ? !rhs : rhs; },
+        or: function(lhs, rhs) { return lhs || rhs; },
+        xor: function(lhs, rhs) { return !lhs != !rhs; },
         nand: function(lhs, rhs) { return !(lhs && rhs); },
-        nor: function(lhs, rhs) { return !(lhs || rhs);  },
-        implies: function(lhs, rhs) { return this.or(this.not(lhs), rhs); },
-        iff: function(lhs, rhs) { return this.and(this.implies(lhs,rhs), this.implies(rhs,lhs)); } 
+        nor: function(lhs, rhs) { return !(lhs || rhs); },
+        implies: function(lhs, rhs) { return !lhs || rhs; },
+        iff: function(lhs, rhs) { return !lhs == !rhs; } 
     };
     
     function getPermutations(items, length) {

--- a/src/WeberLogic.js
+++ b/src/WeberLogic.js
@@ -52,7 +52,7 @@
     function Not(expression) { 
         UnaryOperator.apply(this, arguments);
         this.toString = function () {
-            return "~" + expression;
+            return "¬" + expression;
         };
         this.evaluate = function () {
             return truthTable.not(expression.evaluate());
@@ -83,7 +83,7 @@
     function And(left_expression, right_expression) {
         BinaryOperator.apply(this, arguments);
         this.toString = function () {
-            return "(" + this.left_expression + "&" + this.right_expression + ")";
+            return "(" + this.left_expression + "∧" + this.right_expression + ")";
         };
         this.evaluate = function () {
             return truthTable.and(this.left_expression.evaluate(), this.right_expression.evaluate());
@@ -92,7 +92,7 @@
     function Or(left_expression, right_expression) {
         BinaryOperator.apply(this, arguments);
         this.toString = function () {
-            return "(" + left_expression + "|" + right_expression + ")";
+            return "(" + left_expression + "∨" + right_expression + ")";
         };
         this.evaluate = function () {
             return truthTable.or(this.left_expression.evaluate(), this.right_expression.evaluate());
@@ -101,7 +101,7 @@
     function Xor(left_expression, right_expression) {
         BinaryOperator.apply(this, arguments);
         this.toString = function () {
-            return "(" + left_expression + "^" + right_expression + ")";
+            return "(" + left_expression + "⊻" + right_expression + ")";
         };
         this.evaluate = function () {
             return truthTable.xor(this.left_expression.evaluate(), this.right_expression.evaluate());
@@ -110,7 +110,7 @@
     function Nor(left_expression, right_expression) {
         BinaryOperator.apply(this, arguments);
         this.toString = function () {
-            return "(" + left_expression + "~|" + right_expression + ")";
+            return "(" + left_expression + "⊽" + right_expression + ")";
         };
         this.evaluate = function () {
             return truthTable.nor(this.left_expression.evaluate(), this.right_expression.evaluate());
@@ -119,7 +119,7 @@
     function Nand(left_expression, right_expression) {
         BinaryOperator.apply(this, arguments);
         this.toString = function () {
-            return "(" + left_expression + "~&" + right_expression + ")";
+            return "(" + left_expression + "⊼" + right_expression + ")";
         };
         this.evaluate = function () {
             return truthTable.nand(this.left_expression.evaluate(), this.right_expression.evaluate());
@@ -128,7 +128,7 @@
     function Implies(left_expression, right_expression) {
         BinaryOperator.apply(this, arguments);
         this.toString = function () {
-            return "(" + left_expression + "->" + right_expression + ")";
+            return "(" + left_expression + "⇒" + right_expression + ")";
         };
         this.evaluate = function () {
             return truthTable.implies(this.left_expression.evaluate(), this.right_expression.evaluate());
@@ -137,7 +137,7 @@
     function Iff(left_expression, right_expression) {
         BinaryOperator.apply(this, arguments);
         this.toString = function () {
-            return "(" + left_expression + "<->" + right_expression + ")";
+            return "(" + left_expression + "⇔" + right_expression + ")";
         };
         this.evaluate = function () {
             return truthTable.iff(this.left_expression.evaluate(), this.right_expression.evaluate());

--- a/src/WeberLogic.js
+++ b/src/WeberLogic.js
@@ -98,6 +98,33 @@
             return truthTable.or(this.left_expression.evaluate(), this.right_expression.evaluate());
         };
     }
+    function Xor(left_expression, right_expression) {
+        BinaryOperator.apply(this, arguments);
+        this.toString = function () {
+            return "(" + left_expression + "^" + right_expression + ")";
+        };
+        this.evaluate = function () {
+            return truthTable.xor(this.left_expression.evaluate(), this.right_expression.evaluate());
+        };
+    }
+    function Nor(left_expression, right_expression) {
+        BinaryOperator.apply(this, arguments);
+        this.toString = function () {
+            return "(" + left_expression + "~|" + right_expression + ")";
+        };
+        this.evaluate = function () {
+            return truthTable.nor(this.left_expression.evaluate(), this.right_expression.evaluate());
+        };
+    }
+    function Nand(left_expression, right_expression) {
+        BinaryOperator.apply(this, arguments);
+        this.toString = function () {
+            return "(" + left_expression + "~&" + right_expression + ")";
+        };
+        this.evaluate = function () {
+            return truthTable.nand(this.left_expression.evaluate(), this.right_expression.evaluate());
+        };
+    }
     function Implies(left_expression, right_expression) {
         BinaryOperator.apply(this, arguments);
         this.toString = function () {


### PR DESCRIPTION
I also threw in a commit that splits `and` and `or` into two precedence levels.

Also, all of these changes are untested.